### PR TITLE
Add webhooks generation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ config/tunnel.pid
 .next/
 
 #shopify cli
-./shopify-cli.yml
+.shopify-cli.yml

--- a/.shopify-cli.yml
+++ b/.shopify-cli.yml
@@ -1,2 +1,0 @@
----
-app_type: :node

--- a/.shopify-cli.yml
+++ b/.shopify-cli.yml
@@ -1,0 +1,2 @@
+---
+app_type: :node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1512,6 +1512,26 @@
         "tslib": "1.9.3"
       }
     },
+    "@shopify/koa-shopify-webhooks": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@shopify/koa-shopify-webhooks/-/koa-shopify-webhooks-1.1.8.tgz",
+      "integrity": "sha512-avKdM5PLWHoEaeBvU0JDH/nJiH+WF8fCc/BwGOrJ+5mlE2CyRfmnzKx0G/YGvjuF/2KezdOoKjl6O6d0cNr20g==",
+      "requires": {
+        "@shopify/network": "1.2.4",
+        "koa-bodyparser": "4.2.1",
+        "koa-compose": "4.1.0",
+        "koa-mount": "4.0.0",
+        "safe-compare": "1.1.4"
+      }
+    },
+    "@shopify/network": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@shopify/network/-/network-1.2.4.tgz",
+      "integrity": "sha512-gIK1drVK9ejkGXVPB2GBwWrndH3TYnF37Lb83bjjEbCc1FWWZviIGTwzNPnP7Jv/EKUVva28yUnF9abiKJ8Vxw==",
+      "requires": {
+        "tslib": "1.9.3"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
@@ -3459,6 +3479,11 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
     "cacache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
@@ -3769,6 +3794,17 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "co-body": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.0.0.tgz",
+      "integrity": "sha512-9ZIcixguuuKIptnY8yemEOuhb71L/lLf+Rl5JfJEUiDNJk0e02MBt7BPxR2GEh5mw8dPthQYR4jPI/BnS1MQgw==",
+      "requires": {
+        "inflation": "2.0.0",
+        "qs": "6.5.2",
+        "raw-body": "2.4.0",
+        "type-is": "1.6.16"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3936,6 +3972,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
     "core-js": {
       "version": "2.6.5",
@@ -6036,7 +6077,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -6157,6 +6197,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
     "inflight": {
       "version": "1.0.6",
@@ -7840,6 +7885,15 @@
         }
       }
     },
+    "koa-bodyparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.2.1.tgz",
+      "integrity": "sha512-UIjPAlMZfNYDDe+4zBaOAUKYqkwAGcIU6r2ARf1UOXPAlfennQys5IiShaVeNf7KkVBlf88f2LeLvBFvKylttw==",
+      "requires": {
+        "co-body": "6.0.0",
+        "copy-to": "2.0.1"
+      }
+    },
     "koa-compose": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
@@ -7868,6 +7922,79 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
       "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
+    },
+    "koa-mount": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-mount/-/koa-mount-4.0.0.tgz",
+      "integrity": "sha512-rm71jaA/P+6HeCpoRhmCv8KVBIi0tfGuO/dMKicbQnQW/YJntJ6MnnspkodoA4QstMVEZArsCphmd0bJEtoMjQ==",
+      "requires": {
+        "debug": "4.1.1",
+        "koa-compose": "4.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "koa-router": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.4.0.tgz",
+      "integrity": "sha512-IWhaDXeAnfDBEpWS6hkGdZ1ablgr6Q6pGdXCyK38RbzuH4LkUOpPqPw+3f8l8aTDrQmBQ7xJc0bs2yV4dzcO+g==",
+      "requires": {
+        "debug": "3.2.6",
+        "http-errors": "1.7.2",
+        "koa-compose": "3.2.1",
+        "methods": "1.1.2",
+        "path-to-regexp": "1.7.0",
+        "urijs": "1.19.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "koa-session": {
       "version": "5.10.1",
@@ -8430,6 +8557,11 @@
       "requires": {
         "readable-stream": "2.3.6"
       }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -9779,8 +9911,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -9843,6 +9974,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -10457,8 +10599,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -11698,6 +11839,11 @@
         "crypto-random-string": "1.0.0"
       }
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -11808,6 +11954,11 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8347,6 +8347,11 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node ./server/index.js",
     "generate-page": "node scripts/index.js generate-page",
     "generate-recurring-billing": "node scripts/index.js generate-recurring-billing",
-    "generate-one-time-billing": "node scripts/index.js generate-one-time-billing"
+    "generate-one-time-billing": "node scripts/index.js generate-one-time-billing",
+    "generate-webhooks": "node scripts/index.js generate-webhooks"
   },
   "repository": {
     "type": "git",
@@ -25,11 +26,13 @@
   },
   "dependencies": {
     "@shopify/koa-shopify-auth": "^3.1.25",
+    "@shopify/koa-shopify-webhooks": "^1.1.8",
     "apollo-boost": "^0.3.1",
     "babel-preset-env": "^1.7.0",
     "dotenv": "^7.0.0",
     "graphql": "^14.2.1",
     "koa": "^2.7.0",
+    "koa-router": "^7.4.0",
     "koa-session": "^5.10.1",
     "lodash": "^4.17.11",
     "next": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "koa": "^2.7.0",
     "koa-router": "^7.4.0",
     "koa-session": "^5.10.1",
-    "lodash": "^4.17.11",
+    "lodash.get": "^4.4.2",
     "next": "^8.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/pages/hi.js
+++ b/pages/hi.js
@@ -1,0 +1,2 @@
+const Hi = () => <div>Hi</div>;
+export default Hi;

--- a/pages/hi.js
+++ b/pages/hi.js
@@ -1,2 +1,0 @@
-const Hi = () => <div>Hi</div>;
-export default Hi;

--- a/scripts/billing/generate-one-time-charge.js
+++ b/scripts/billing/generate-one-time-charge.js
@@ -2,7 +2,7 @@ const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
 const get = require("lodash/get");
 
-const code = `server.context.client = await createClient(ctx.session);
+const code = `server.context.client = await createClient(shop, accessToken);
 await getOneTimeUrl(ctx);
 `;
 const generateOneTimeCharge = ast => {

--- a/scripts/billing/generate-one-time-charge.js
+++ b/scripts/billing/generate-one-time-charge.js
@@ -1,6 +1,6 @@
 const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 
 const code = `server.context.client = await createClient(shop, accessToken);
 await getOneTimeUrl(ctx);

--- a/scripts/billing/generate-recurring-billing.js
+++ b/scripts/billing/generate-recurring-billing.js
@@ -2,7 +2,7 @@ const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
 const get = require("lodash/get");
 
-const code = `server.context.client = await handlers.createClient(ctx.session);
+const code = `server.context.client = await handlers.createClient(shop, accessToken);
 await handlers.getSubscriptionUrl(ctx);
 `;
 const generateRecurringBilling = ast => {

--- a/scripts/billing/generate-recurring-billing.js
+++ b/scripts/billing/generate-recurring-billing.js
@@ -1,6 +1,6 @@
 const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 
 const code = `server.context.client = await handlers.createClient(shop, accessToken);
 await handlers.getSubscriptionUrl(ctx);

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,23 +7,22 @@ function receiveArgs(args) {
       break;
     }
     case "generate-recurring-billing": {
-      const generateRecurringBilling = require("./generate-recurring-billing");
+      const generateRecurringBilling = require("./billing/generate-recurring-billing");
       const transform = require("./transform");
       transform("server/server.js", generateRecurringBilling);
       break;
     }
     case "generate-one-time-billing": {
-      const generateOneTimeCharge = require("./generate-one-time-charge");
+      const generateOneTimeCharge = require("./billing/generate-one-time-charge");
       const transform = require("./transform");
       transform("server/server.js", generateOneTimeCharge);
       break;
     }
     case "generate-webhooks": {
-      const type = args[3].toString();
-      const url = args[4].toString();
-      const generateWebhooks = require("./generate-webhooks");
+      const type = args[3];
+      const generateWebhooks = require("./webhooks/generate-webhooks");
       const transform = require("./transform");
-      transform("server/server.js", generateWebhooks, type, url);
+      transform("server/server.js", generateWebhooks, type);
       break;
     }
     default:

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -18,6 +18,14 @@ function receiveArgs(args) {
       transform("server/server.js", generateOneTimeCharge);
       break;
     }
+    case "generate-webhooks": {
+      const type = args[3].toString();
+      const url = args[4].toString();
+      const generateWebhooks = require("./generate-webhooks");
+      const transform = require("./transform");
+      transform("server/server.js", generateWebhooks, type, url);
+      break;
+    }
     default:
       console.log("Please provide a command");
   }

--- a/scripts/tests/generate-billing.test.js
+++ b/scripts/tests/generate-billing.test.js
@@ -1,28 +1,11 @@
-const generateRecurringBilling = require("../generate-recurring-billing");
+const generateRecurringBilling = require("../billing/generate-recurring-billing");
 const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
-
-const server = `createShopifyAuth({
-    async afterAuth(ctx) {
-      const { shop } = ctx.session;
-      ctx.redirect("/");
-    }
-  })`;
-
-const transformed = `createShopifyAuth({
-  async afterAuth(ctx) {
-    const {
-      shop
-    } = ctx.session;
-    server.context.client = await handlers.createClient(ctx.session);
-    await handlers.getSubscriptionUrl(ctx);
-  }
-
-});`;
+const { auth, transformedAuth } = require("./server-mocks");
 
 it("should return the new code with call to billing api", () => {
-  const ast = parser(server, { sourceType: "module" });
+  const ast = parser(auth, { sourceType: "module" });
   const parsedAst = generateRecurringBilling(ast);
   const newCode = generate(parsedAst).code;
-  expect(newCode).toBe(transformed);
+  expect(newCode).toBe(transformedAuth);
 });

--- a/scripts/tests/generate-webhooks.test.js
+++ b/scripts/tests/generate-webhooks.test.js
@@ -1,0 +1,30 @@
+const generateWebhooks = require("../webhooks/generate-webhooks");
+const parser = require("@babel/parser").parse;
+const generate = require("@babel/generator").default;
+const {
+  server,
+  transformedWithMoreWebhooks,
+  transformedWithWebhooksandEnv,
+  scopes
+} = require("./server-mocks");
+
+it("should return the new code with call to billing api", () => {
+  const ast = parser(server, { sourceType: "module" });
+  const parsedAst = generateWebhooks(ast, "TEST_TYPE");
+  const newCode = generate(parsedAst).code;
+  expect(newCode).toBe(transformedWithWebhooksandEnv);
+});
+
+it("should only add the webhook subscription and registration if receiveWehook is already in file", () => {
+  const ast = parser(transformedWithWebhooksandEnv, { sourceType: "module" });
+  const parsedAst = generateWebhooks(ast, "TEST_TWO");
+  const newCode = generate(parsedAst).code;
+  expect(newCode).toBe(transformedWithMoreWebhooks);
+});
+
+it("should not add new scope if scope is already there", () => {
+  const ast = parser(scopes, { sourceType: "module" });
+  const parsedAst = generateWebhooks(ast, "TEST_TWO");
+  const newCode = generate(parsedAst).code;
+  expect(newCode).toBe(scopes);
+});

--- a/scripts/tests/server-mocks.js
+++ b/scripts/tests/server-mocks.js
@@ -1,0 +1,135 @@
+const auth = `createShopifyAuth({
+  async afterAuth(ctx) {
+    const { shop, accessToken } = ctx.session;
+    ctx.redirect("/");
+  }
+})`;
+
+const transformedAuth = `createShopifyAuth({
+  async afterAuth(ctx) {
+    const {
+      shop,
+      accessToken
+    } = ctx.session;
+    server.context.client = await handlers.createClient(shop, accessToken);
+    await handlers.getSubscriptionUrl(ctx);
+  }
+
+});`;
+
+const server = `import * as handlers from "./handlers/index";
+const { SHOPIFY_API_SECRET_KEY, SHOPIFY_API_KEY } = process.env;
+
+dotenv.config();
+app.prepare().then(() => {
+  const server = new Koa();
+  const router = new Router();
+  server.use(
+    createShopifyAuth({
+      scopes: ["read_products", "write_products"],
+
+      async afterAuth(ctx) {
+        const { shop, accessToken } = ctx.session;
+        ctx.redirect("/");
+      }
+    })
+  );
+  router.get("*", verifyRequest(), async ctx => {
+    await handle(ctx.req, ctx.res);
+    ctx.respond = false;
+    ctx.res.statusCode = 200;
+  });
+});`;
+
+const transformedWithWebhooksandEnv = `import * as handlers from "./handlers/index";
+const {
+  SHOPIFY_API_SECRET_KEY,
+  SHOPIFY_API_KEY
+} = process.env;
+import { receiveWebhook } from '@shopify/koa-shopify-webhooks';
+
+dotenv.config();
+app.prepare().then(() => {
+  const server = new Koa();
+  const router = new Router();
+  const webhook = receiveWebhook({
+    secret: SHOPIFY_API_SECRET_KEY
+  });
+
+  server.use(createShopifyAuth({
+    scopes: ["read_products", "write_products"],
+
+    async afterAuth(ctx) {
+      const {
+        shop,
+        accessToken
+      } = ctx.session;
+      await handlers.registerWebhooks(shop, accessToken, 'TEST_TYPE', '/webhooks/test/type');
+
+      ctx.redirect("/");
+    }
+
+  }));
+  router.post('/webhooks/test/type', webhook, ctx => {
+    console.log('received webhook: ', ctx.state.webhook);
+  });
+
+  router.get("*", verifyRequest(), async ctx => {
+    await handle(ctx.req, ctx.res);
+    ctx.respond = false;
+    ctx.res.statusCode = 200;
+  });
+});`;
+
+const transformedWithMoreWebhooks = `import * as handlers from "./handlers/index";
+const {
+  SHOPIFY_API_SECRET_KEY,
+  SHOPIFY_API_KEY
+} = process.env;
+import { receiveWebhook } from '@shopify/koa-shopify-webhooks';
+dotenv.config();
+app.prepare().then(() => {
+  const server = new Koa();
+  const router = new Router();
+  const webhook = receiveWebhook({
+    secret: SHOPIFY_API_SECRET_KEY
+  });
+  server.use(createShopifyAuth({
+    scopes: ["read_products", "write_products"],
+
+    async afterAuth(ctx) {
+      const {
+        shop,
+        accessToken
+      } = ctx.session;
+      await handlers.registerWebhooks(shop, accessToken, 'TEST_TWO', '/webhooks/test/two');
+
+      await handlers.registerWebhooks(shop, accessToken, 'TEST_TYPE', '/webhooks/test/type');
+      ctx.redirect("/");
+    }
+
+  }));
+  router.post('/webhooks/test/type', webhook, ctx => {
+    console.log('received webhook: ', ctx.state.webhook);
+  });
+  router.post('/webhooks/test/two', webhook, ctx => {
+    console.log('received webhook: ', ctx.state.webhook);
+  });
+
+  router.get("*", verifyRequest(), async ctx => {
+    await handle(ctx.req, ctx.res);
+    ctx.respond = false;
+    ctx.res.statusCode = 200;
+  });
+});`;
+
+const scopes = `scopes: ["read_products", "write_products"];`;
+
+module.exports = {
+  transformedWithMoreWebhooks,
+  transformedWithWebhooksandEnv,
+  server,
+  auth,
+  transformedAuth,
+  scopes
+};

--- a/scripts/tests/utilities.test.js
+++ b/scripts/tests/utilities.test.js
@@ -1,0 +1,5 @@
+const { createWebhooksUrl } = require("../utilities");
+
+it("should transform string into webhooks specific url", () => {
+  expect(createWebhooksUrl("TEST_CREATE")).toBe("/webhooks/test/create");
+});

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -3,11 +3,10 @@ const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
 const prettier = require("prettier");
 
-const transform = (fileToWrite, transformer) => {
+const transform = (fileToWrite, transformer, type, url) => {
   const file = fs.readFileSync(fileToWrite).toString();
   const ast = parser(file, { sourceType: "module" });
-  const newCode = generate(transformer(ast)).code;
-
+  const newCode = generate(transformer(ast, type, url)).code;
   const prettifiedCode = prettier.format(newCode, { parser: "babel" });
   fs.writeFileSync(fileToWrite, prettifiedCode, err => {
     if (err) throw new Error(`${err}`);

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -3,10 +3,10 @@ const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
 const prettier = require("prettier");
 
-const transform = (fileToWrite, transformer, type, url) => {
+const transform = (fileToWrite, transformer, type) => {
   const file = fs.readFileSync(fileToWrite).toString();
   const ast = parser(file, { sourceType: "module" });
-  const newCode = generate(transformer(ast, type, url)).code;
+  const newCode = generate(transformer(ast, type)).code;
   const prettifiedCode = prettier.format(newCode, { parser: "babel" });
   fs.writeFileSync(fileToWrite, prettifiedCode, err => {
     if (err) throw new Error(`${err}`);

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,0 +1,10 @@
+const replace = require("lodash/replace");
+const lowerCase = require("lodash/lowerCase");
+
+const createWebhooksUrl = type => {
+  const transformedString = replace(lowerCase(type), " ", "/");
+  return `/webhooks/${transformedString}`;
+};
+module.exports = {
+  createWebhooksUrl
+};

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,9 +1,6 @@
-const replace = require("lodash/replace");
-const lowerCase = require("lodash/lowerCase");
-
 const createWebhooksUrl = type => {
-  const transformedString = replace(lowerCase(type), " ", "/");
-  return `/webhooks/${transformedString}`;
+  const transformedString = type.replace("_", "/");
+  return `/webhooks/${transformedString.toLowerCase()}`;
 };
 module.exports = {
   createWebhooksUrl

--- a/scripts/webhooks/generate-scopes.js
+++ b/scripts/webhooks/generate-scopes.js
@@ -1,0 +1,27 @@
+const traverse = require("@babel/traverse").default;
+const get = require("lodash/get");
+const t = require("@babel/types");
+
+const generateWebhooks = ast => {
+  let appScope;
+  const scope = "write_products";
+  const hasItem = item => item.value === scope;
+  traverse(ast, {
+    Property(path) {
+      const getLine = get(path, ["node", "key", "name"]);
+      const getNode = get(path, ["node", "value", "elements"]);
+      if (getLine === "scopes") {
+        appScope = getNode;
+      }
+    }
+  });
+  if (!appScope) {
+    return ast;
+  }
+  if (!appScope.find(hasItem)) {
+    appScope.push(t.stringLiteral(scope));
+  }
+  return ast;
+};
+
+module.exports = generateWebhooks;

--- a/scripts/webhooks/generate-scopes.js
+++ b/scripts/webhooks/generate-scopes.js
@@ -1,5 +1,5 @@
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 const t = require("@babel/types");
 
 const generateWebhooks = ast => {

--- a/scripts/webhooks/generate-webhhoks-subscription.js
+++ b/scripts/webhooks/generate-webhhoks-subscription.js
@@ -1,6 +1,6 @@
 const parseExpression = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 const { createWebhooksUrl } = require("../utilities");
 const generateWebhooksEnvironment = require("./generate-webhooks-environment");
 

--- a/scripts/webhooks/generate-webhhoks-subscription.js
+++ b/scripts/webhooks/generate-webhhoks-subscription.js
@@ -1,0 +1,32 @@
+const parseExpression = require("@babel/parser").parse;
+const traverse = require("@babel/traverse").default;
+const get = require("lodash/get");
+
+const generateWebhooksSubscription = (ast, type, url) => {
+  let verifyMiddleware;
+  traverse(ast, {
+    CallExpression(path) {
+      const test = get(path, ["node", "callee", "name"]);
+      if (test === "verifyRequest") {
+        verifyMiddleware = path.getStatementParent();
+      }
+    }
+  });
+
+  if (!verifyMiddleware) {
+    return ast;
+  }
+  const code = `router.post('/webhooks/products/create', webhook, (ctx) => {
+    console.log('received webhook: ', ctx.state.webhook);
+  });`;
+
+  verifyMiddleware.insertBefore(
+    parseExpression(code, {
+      sourceType: "module",
+      allowAwaitOutsideFunction: true
+    })
+  );
+  return ast;
+};
+
+module.exports = generateWebhooksSubscription;

--- a/scripts/webhooks/generate-webhooks-environment.js
+++ b/scripts/webhooks/generate-webhooks-environment.js
@@ -1,0 +1,57 @@
+const parseExpression = require("@babel/parser").parse;
+const traverse = require("@babel/traverse").default;
+const get = require("lodash/get");
+const generateWebhooksSubscription = require("./webhooks/generate-webhhoks-subscription");
+
+const generateWebhooksEnvironment = (ast, url) => {
+  const code = `const webhook = receiveWebhook({secret: SHOPIFY_API_SECRET_KEY});`;
+  const package = `import { receiveWebhook } from '@shopify/koa-shopify-webhooks';`;
+  let webhookDeclaration;
+  let routerDeclaration;
+  let enviroment;
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const indentifierName = get(path, ["node", "id", "name"]);
+      if (indentifierName === "webhook") {
+        webhookDeclaration = path;
+      }
+    }
+  });
+
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const indentifierName = get(path, ["node", "id", "name"]);
+      if (indentifierName === "router") {
+        routerDeclaration = path.getStatementParent();
+      }
+    }
+  });
+
+  traverse(ast, {
+    MemberExpression(path) {
+      const dotEnv = get(path, ["node", "object", "name"]);
+      if (dotEnv === "dotenv") {
+        enviroment = path.getStatementParent();
+      }
+    }
+  });
+
+  if (webhookDeclaration) {
+    return generateWebhooksSubscription(ast);
+  }
+  routerDeclaration.insertAfter(
+    parseExpression(code, {
+      sourceType: "module",
+      allowAwaitOutsideFunction: true
+    })
+  );
+  enviroment.insertBefore(
+    parseExpression(package, {
+      sourceType: "module",
+      allowAwaitOutsideFunction: true
+    })
+  );
+  return generateWebhooksSubscription(ast, url);
+};
+
+module.exports = generateWebhooksEnvironment;

--- a/scripts/webhooks/generate-webhooks-environment.js
+++ b/scripts/webhooks/generate-webhooks-environment.js
@@ -1,14 +1,14 @@
 const parseExpression = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
 const get = require("lodash/get");
-const generateWebhooksSubscription = require("./webhooks/generate-webhhoks-subscription");
+const generateScopes = require("./generate-scopes");
 
-const generateWebhooksEnvironment = (ast, url) => {
+const generateWebhooksEnvironment = ast => {
   const code = `const webhook = receiveWebhook({secret: SHOPIFY_API_SECRET_KEY});`;
-  const package = `import { receiveWebhook } from '@shopify/koa-shopify-webhooks';`;
+  const importPackage = `import { receiveWebhook } from '@shopify/koa-shopify-webhooks';`;
   let webhookDeclaration;
   let routerDeclaration;
-  let enviroment;
+  let env;
   traverse(ast, {
     VariableDeclarator(path) {
       const indentifierName = get(path, ["node", "id", "name"]);
@@ -31,27 +31,25 @@ const generateWebhooksEnvironment = (ast, url) => {
     MemberExpression(path) {
       const dotEnv = get(path, ["node", "object", "name"]);
       if (dotEnv === "dotenv") {
-        enviroment = path.getStatementParent();
+        env = path.getStatementParent();
       }
     }
   });
 
   if (webhookDeclaration) {
-    return generateWebhooksSubscription(ast);
+    return generateScopes(ast);
   }
   routerDeclaration.insertAfter(
     parseExpression(code, {
-      sourceType: "module",
-      allowAwaitOutsideFunction: true
+      sourceType: "module"
     })
   );
-  enviroment.insertBefore(
-    parseExpression(package, {
-      sourceType: "module",
-      allowAwaitOutsideFunction: true
+  env.insertBefore(
+    parseExpression(importPackage, {
+      sourceType: "module"
     })
   );
-  return generateWebhooksSubscription(ast, url);
+  return generateScopes(ast);
 };
 
 module.exports = generateWebhooksEnvironment;

--- a/scripts/webhooks/generate-webhooks-environment.js
+++ b/scripts/webhooks/generate-webhooks-environment.js
@@ -1,6 +1,6 @@
 const parseExpression = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 const generateScopes = require("./generate-scopes");
 
 const generateWebhooksEnvironment = ast => {

--- a/scripts/webhooks/generate-webhooks.js
+++ b/scripts/webhooks/generate-webhooks.js
@@ -1,0 +1,34 @@
+const parser = require("@babel/parser").parse;
+const traverse = require("@babel/traverse").default;
+const get = require("lodash/get");
+const generateWebhooksEnvironment = require("./webhooks/generate-webhooks-environment");
+
+const generateWebhooks = (ast, type, url) => {
+  let sessionAssignment;
+  traverse(ast, {
+    VariableDeclaration(path) {
+      const variableinAuth = get(path, ["node", "declarations"])[0];
+      const properties = get(variableinAuth, ["id", "properties"]);
+      if (properties) {
+        properties.filter(prop => {
+          return get(prop, ["key", "name"]) == "shop";
+        });
+        sessionAssignment = path;
+      }
+    }
+  });
+
+  if (!sessionAssignment) {
+    return ast;
+  }
+  console.log(url);
+  console.log(type);
+  const code = `handlers.registerWebhooks(shop, accessToken, ${type}, "${url}");`;
+  console.log(code);
+  sessionAssignment.insertAfter(
+    parser(code, { sourceType: "module", allowAwaitOutsideFunction: true })
+  );
+  return generateWebhooksEnvironment(ast, url);
+};
+
+module.exports = generateWebhooks;

--- a/scripts/webhooks/generate-webhooks.js
+++ b/scripts/webhooks/generate-webhooks.js
@@ -1,6 +1,6 @@
 const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
-const get = require("lodash/get");
+const get = require("lodash.get");
 const generateWebhooksSubcription = require("./generate-webhhoks-subscription");
 const { createWebhooksUrl } = require("../utilities");
 

--- a/scripts/webhooks/generate-webhooks.js
+++ b/scripts/webhooks/generate-webhooks.js
@@ -1,9 +1,10 @@
 const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
 const get = require("lodash/get");
-const generateWebhooksEnvironment = require("./webhooks/generate-webhooks-environment");
+const generateWebhooksSubcription = require("./generate-webhhoks-subscription");
+const { createWebhooksUrl } = require("../utilities");
 
-const generateWebhooks = (ast, type, url) => {
+const generateWebhooks = (ast, type) => {
   let sessionAssignment;
   traverse(ast, {
     VariableDeclaration(path) {
@@ -21,14 +22,13 @@ const generateWebhooks = (ast, type, url) => {
   if (!sessionAssignment) {
     return ast;
   }
-  console.log(url);
-  console.log(type);
-  const code = `handlers.registerWebhooks(shop, accessToken, ${type}, "${url}");`;
-  console.log(code);
+  const code = `await handlers.registerWebhooks(shop, accessToken, '${type}', '${createWebhooksUrl(
+    type
+  )}'); `;
   sessionAssignment.insertAfter(
     parser(code, { sourceType: "module", allowAwaitOutsideFunction: true })
   );
-  return generateWebhooksEnvironment(ast, url);
+  return generateWebhooksSubcription(ast, type);
 };
 
 module.exports = generateWebhooks;

--- a/server/handlers/client.js
+++ b/server/handlers/client.js
@@ -1,16 +1,14 @@
-import ApolloClient from 'apollo-boost';
+import ApolloClient from "apollo-boost";
 
-export const createClient = (session) => {
-  const { shop, accessToken } = session;
-
+export const createClient = (shop, accessToken) => {
   return new ApolloClient({
     uri: `https://${shop}/admin/api/unstable/graphql.json`,
     request: operation => {
       operation.setContext({
         headers: {
-          'X-Shopify-Access-Token': accessToken,
-        },
+          "X-Shopify-Access-Token": accessToken
+        }
       });
-    },
+    }
   });
 };

--- a/server/handlers/index.js
+++ b/server/handlers/index.js
@@ -1,9 +1,6 @@
-import { getSubscriptionUrl } from './mutations/get-subscription-url';
-import { getOneTimeUrl } from './mutations/get-one-time-url';
-import { createClient } from './client';
+import { getSubscriptionUrl } from "./mutations/get-subscription-url";
+import { getOneTimeUrl } from "./mutations/get-one-time-url";
+import { createClient } from "./client";
+import { registerWebhooks } from "./register-webhooks";
 
-export {
-  getSubscriptionUrl,
-  getOneTimeUrl,
-  createClient
-};
+export { getSubscriptionUrl, getOneTimeUrl, createClient, registerWebhooks };

--- a/server/handlers/register-webhooks.js
+++ b/server/handlers/register-webhooks.js
@@ -2,7 +2,7 @@ import { registerWebhook } from "@shopify/koa-shopify-webhooks";
 
 export const registerWebhooks = async (shop, accessToken, type, url) => {
   const registration = await registerWebhook({
-    address: `${process.env.TUNNEL_URL}/${url}`,
+    address: `${process.env.TUNNEL_URL}${url}`,
     topic: type,
     accessToken,
     shop

--- a/server/handlers/register-webhooks.js
+++ b/server/handlers/register-webhooks.js
@@ -1,0 +1,19 @@
+import { registerWebhook } from "@shopify/koa-shopify-webhooks";
+
+export const registerWebhooks = async (shop, accessToken, type, url) => {
+  const registration = await registerWebhook({
+    address: `${process.env.TUNNEL_URL}/${url}`,
+    topic: type,
+    accessToken,
+    shop
+  });
+
+  if (registration.success) {
+    console.log("Successfully registered webhook!");
+  } else {
+    console.log(
+      "Failed to register webhook",
+      registration.result.data.webhookSubscriptionCreate
+    );
+  }
+};

--- a/server/server.js
+++ b/server/server.js
@@ -2,10 +2,13 @@ import "isomorphic-fetch";
 import dotenv from "dotenv";
 import "@babel/polyfill";
 import Koa from "koa";
+import Router from "koa-router";
 import next from "next";
 import createShopifyAuth, { verifyRequest } from "@shopify/koa-shopify-auth";
 import session from "koa-session";
 import * as handlers from "./handlers/index";
+import { receiveWebhook } from "@shopify/koa-shopify-webhooks";
+
 dotenv.config();
 const port = parseInt(process.env.PORT, 10) || 8081;
 const dev = process.env.NODE_ENV !== "production";
@@ -16,29 +19,45 @@ const handle = app.getRequestHandler();
 const { SHOPIFY_API_SECRET_KEY, SHOPIFY_API_KEY } = process.env;
 app.prepare().then(() => {
   const server = new Koa();
+  const router = new Router();
+  const webhook = receiveWebhook({
+    secret: SHOPIFY_API_SECRET_KEY
+  });
+
   server.use(session(server));
   server.keys = [SHOPIFY_API_SECRET_KEY];
   server.use(
     createShopifyAuth({
       apiKey: SHOPIFY_API_KEY,
       secret: SHOPIFY_API_SECRET_KEY,
-      scopes: ["read_products"],
+      scopes: ["read_products", "write_products"],
 
       async afterAuth(ctx) {
         //Auth token and shop available in sesssion
         //Redirect to shop upon auth
-        const { shop } = ctx.session;
+        const { shop, accessToken } = ctx.session;
+        handlers.registerWebhooks(
+          shop,
+          accessToken,
+          PRODUCTS_CREATE,
+          "/webhooks/products/create"
+        );
+
         ctx.redirect("/");
       }
     })
   );
-  server.use(verifyRequest());
-  server.use(async ctx => {
+  router.post("/webhooks/products/create", webhook, ctx => {
+    console.log("received webhook: ", ctx.state.webhook);
+  });
+
+  router.get("*", verifyRequest(), async ctx => {
     await handle(ctx.req, ctx.res);
     ctx.respond = false;
     ctx.res.statusCode = 200;
-    return;
   });
+  server.use(router.allowedMethods());
+  server.use(router.routes());
   server.listen(port, () => {
     console.log(`> Ready on http://localhost:${port}`);
   });

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,6 @@ import next from "next";
 import createShopifyAuth, { verifyRequest } from "@shopify/koa-shopify-auth";
 import session from "koa-session";
 import * as handlers from "./handlers/index";
-
 dotenv.config();
 const port = parseInt(process.env.PORT, 10) || 8081;
 const dev = process.env.NODE_ENV !== "production";
@@ -31,6 +30,7 @@ app.prepare().then(() => {
         //Auth token and shop available in sesssion
         //Redirect to shop upon auth
         const { shop, accessToken } = ctx.session;
+
         ctx.redirect("/");
       }
     })


### PR DESCRIPTION
This adds the ability to create create webhooks subscriptions and receive webhooks.

This work assumes that the cli will run: `npm run-script generate-webhooks WEBHOOKS_TOPIC`

At this time, I have hardcoded a scope for the array as I'm not sure how we're planning passing it to the command line. We could just pass it as an arg to the script like the `TOPIC`. 

The app will generate the URLS through the [createWebhooksUrl](https://github.com/Shopify/webgen-embeddedapp/compare/add-webhooks?expand=1#diff-0c58aff4abebd9398603910227ca8db6R4) helper.

This PR also updates the [server](https://github.com/Shopify/webgen-embeddedapp/pull/18/files#diff-ea75b530d74f94670cea053feb8b961bR44) to handle routes with `verifyRequest`

Last thing, moved some files around into subfolders and put a bunch of mocks/responses for the server tests in old file.
👋