### PR TITLE
Fix billing

### DIFF
--- a/scripts/billing/generate-one-time-charge.js
+++ b/scripts/billing/generate-one-time-charge.js
@@ -2,11 +2,11 @@ const parser = require("@babel/parser").parse;
 const traverse = require("@babel/traverse").default;
 const get = require("lodash.get");
 
-const code = `server.context.client = await createClient(shop, accessToken);
-await getOneTimeUrl(ctx);
-`;
+const client = `server.context.client = await handlers.createClient(shop, accessToken)`;
+const handlerLine = `await handlers.getOneTimeUrl(ctx)`;
 const generateOneTimeCharge = ast => {
   let redirectAfterAuth;
+  let handlerPath;
   traverse(ast, {
     ExpressionStatement(path) {
       const getName = get(path, [
@@ -16,19 +16,46 @@ const generateOneTimeCharge = ast => {
         "object",
         "name"
       ]);
+      const getIdentifier = get(path, [
+        "node",
+        "expression",
+        "argument",
+        "callee",
+        "property",
+        "name"
+      ]);
       if (getName === "ctx") {
         redirectAfterAuth = path;
+      }
+      if (getIdentifier === "getSubscriptionUrl") {
+        handlerPath = path;
       }
     }
   });
 
-  if (!redirectAfterAuth) {
+  if (!redirectAfterAuth && !handlerPath) {
     return ast;
   }
 
-  redirectAfterAuth.replaceWith(
-    parser(code, { sourceType: "module", allowAwaitOutsideFunction: true })
-  );
+  if (handlerPath) {
+    handlerPath.replaceWith(
+      parser(handlerLine, {
+        sourceType: "module",
+        allowAwaitOutsideFunction: true
+      })
+    );
+  }
+  if (redirectAfterAuth) {
+    redirectAfterAuth.insertBefore(
+      parser(client, { sourceType: "module", allowAwaitOutsideFunction: true })
+    );
+    redirectAfterAuth.replaceWith(
+      parser(handlerLine, {
+        sourceType: "module",
+        allowAwaitOutsideFunction: true
+      })
+    );
+  }
   return ast;
 };
 

--- a/scripts/tests/generate-billing.test.js
+++ b/scripts/tests/generate-billing.test.js
@@ -1,11 +1,23 @@
 const generateRecurringBilling = require("../billing/generate-recurring-billing");
 const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
-const { auth, transformedAuth } = require("./server-mocks");
+const {
+  auth,
+  authWithHandler,
+  transformedAuthWithHandler,
+  transformedAuth
+} = require("./server-mocks");
 
 it("should return the new code with call to billing api", () => {
   const ast = parser(auth, { sourceType: "module" });
   const parsedAst = generateRecurringBilling(ast);
   const newCode = generate(parsedAst).code;
   expect(newCode).toBe(transformedAuth);
+});
+
+it("should replace handler if you've already generated billing code", () => {
+  const ast = parser(authWithHandler, { sourceType: "module" });
+  const parsedAst = generateRecurringBilling(ast);
+  const newCode = generate(parsedAst).code;
+  expect(newCode).toBe(transformedAuthWithHandler);
 });

--- a/scripts/tests/generate-webhook.test.js
+++ b/scripts/tests/generate-webhook.test.js
@@ -7,7 +7,7 @@ const {
   transformedWithWebhooksandEnv
 } = require("./server-mocks");
 
-it("should return the new code with call to billing api", () => {
+it("should return the new code with registered webhooks", () => {
   const ast = parser(server, { sourceType: "module" });
   const parsedAst = generateWebhook(ast, "TEST_TYPE");
   const newCode = generate(parsedAst).code;

--- a/scripts/tests/server-mocks.js
+++ b/scripts/tests/server-mocks.js
@@ -61,9 +61,9 @@ app.prepare().then(() => {
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-}); `;
+});`;
 
-const transformedWithWebhooksandEnv = `import * as handlers from "./handlers/index";
+const transformedWithWebhooksandEnv = `import * as handlers from \"./handlers/index\";
 const {
   SHOPIFY_API_SECRET_KEY,
   SHOPIFY_API_KEY
@@ -79,7 +79,7 @@ app.prepare().then(() => {
   });
 
   server.use(createShopifyAuth({
-    scopes: ["read_products", "write_products"],
+    scopes: [\"read_products\", \"write_products\"],
 
     async afterAuth(ctx) {
       const {
@@ -88,7 +88,7 @@ app.prepare().then(() => {
       } = ctx.session;
       await handlers.registerWebhooks(shop, accessToken, 'TEST_TYPE', '/webhooks/test/type');
 
-      ctx.redirect("/");
+      ctx.redirect(\"/\");
     }
 
   }));
@@ -96,14 +96,14 @@ app.prepare().then(() => {
     console.log('received webhook: ', ctx.state.webhook);
   });
 
-  router.get("*", verifyRequest(), async ctx => {
+  router.get(\"*\", verifyRequest(), async ctx => {
     await handle(ctx.req, ctx.res);
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-}); `;
+});`;
 
-const transformedWithMoreWebhooks = `import * as handlers from "./handlers/index";
+const transformedWithMoreWebhooks = `import * as handlers from \"./handlers/index\";
 const {
   SHOPIFY_API_SECRET_KEY,
   SHOPIFY_API_KEY
@@ -117,7 +117,7 @@ app.prepare().then(() => {
     secret: SHOPIFY_API_SECRET_KEY
   });
   server.use(createShopifyAuth({
-    scopes: ["read_products", "write_products"],
+    scopes: [\"read_products\", \"write_products\"],
 
     async afterAuth(ctx) {
       const {
@@ -127,7 +127,7 @@ app.prepare().then(() => {
       await handlers.registerWebhooks(shop, accessToken, 'TEST_TWO', '/webhooks/test/two');
 
       await handlers.registerWebhooks(shop, accessToken, 'TEST_TYPE', '/webhooks/test/type');
-      ctx.redirect("/");
+      ctx.redirect(\"/\");
     }
 
   }));
@@ -138,12 +138,12 @@ app.prepare().then(() => {
     console.log('received webhook: ', ctx.state.webhook);
   });
 
-  router.get("*", verifyRequest(), async ctx => {
+  router.get(\"*\", verifyRequest(), async ctx => {
     await handle(ctx.req, ctx.res);
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-}); `;
+});`;
 
 module.exports = {
   transformedWithMoreWebhooks,

--- a/scripts/tests/server-mocks.js
+++ b/scripts/tests/server-mocks.js
@@ -5,6 +5,27 @@ const auth = `createShopifyAuth({
   }
 })`;
 
+const authWithHandler = `createShopifyAuth({
+  async afterAuth(ctx) {
+    const { shop, accessToken } = ctx.session;
+    server.context.client = await handlers.createClient(shop, accessToken);
+    await handlers.getOneTimeUrl(ctx);
+
+  }
+})`;
+
+const transformedAuthWithHandler = `createShopifyAuth({
+  async afterAuth(ctx) {
+    const {
+      shop,
+      accessToken
+    } = ctx.session;
+    server.context.client = await handlers.createClient(shop, accessToken);
+    await handlers.getSubscriptionUrl(ctx);
+  }
+
+});`;
+
 const transformedAuth = `createShopifyAuth({
   async afterAuth(ctx) {
     const {
@@ -12,6 +33,7 @@ const transformedAuth = `createShopifyAuth({
       accessToken
     } = ctx.session;
     server.context.client = await handlers.createClient(shop, accessToken);
+
     await handlers.getSubscriptionUrl(ctx);
   }
 
@@ -39,7 +61,7 @@ app.prepare().then(() => {
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-});`;
+}); `;
 
 const transformedWithWebhooksandEnv = `import * as handlers from "./handlers/index";
 const {
@@ -79,7 +101,7 @@ app.prepare().then(() => {
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-});`;
+}); `;
 
 const transformedWithMoreWebhooks = `import * as handlers from "./handlers/index";
 const {
@@ -121,12 +143,14 @@ app.prepare().then(() => {
     ctx.respond = false;
     ctx.res.statusCode = 200;
   });
-});`;
+}); `;
 
 module.exports = {
   transformedWithMoreWebhooks,
   transformedWithWebhooksandEnv,
   server,
   auth,
-  transformedAuth
+  transformedAuth,
+  authWithHandler,
+  transformedAuthWithHandler
 };

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -3,12 +3,13 @@ const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
 const prettier = require("prettier");
 
-const transform = (fileToWrite, transformer, type) => {
+const transform = async (fileToWrite, transformer, type) => {
   const file = fs.readFileSync(fileToWrite).toString();
   const ast = parser(file, { sourceType: "module" });
   const newCode = generate(transformer(ast, type)).code;
   const prettifiedCode = prettier.format(newCode, { parser: "babel" });
-  fs.writeFileSync(fileToWrite, prettifiedCode, err => {
+  await fs.writeFileSync(fileToWrite, prettifiedCode, err => {
+    console.log("ran");
     if (err) throw new Error(`${err}`);
     console.log(`Scaffold was successfully added to ${fileToWrite}!`);
   });

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -3,13 +3,12 @@ const parser = require("@babel/parser").parse;
 const generate = require("@babel/generator").default;
 const prettier = require("prettier");
 
-const transform = async (fileToWrite, transformer, type) => {
+const transform = (fileToWrite, transformer, type) => {
   const file = fs.readFileSync(fileToWrite).toString();
   const ast = parser(file, { sourceType: "module" });
   const newCode = generate(transformer(ast, type)).code;
   const prettifiedCode = prettier.format(newCode, { parser: "babel" });
-  await fs.writeFileSync(fileToWrite, prettifiedCode, err => {
-    console.log("ran");
+  fs.writeFileSync(fileToWrite, prettifiedCode, err => {
     if (err) throw new Error(`${err}`);
     console.log(`Scaffold was successfully added to ${fileToWrite}!`);
   });

--- a/server/server.js
+++ b/server/server.js
@@ -34,7 +34,6 @@ app.prepare().then(() => {
       }
     })
   );
-
   router.get("*", verifyRequest(), async ctx => {
     await handle(ctx.req, ctx.res);
     ctx.respond = false;


### PR DESCRIPTION
This is a fix for the billing command, it was checking for the `ctx.redirect` node, but if a user had already run the command, that node doesn't exist. Now it replaces the existing handler with the new one. 

I plan on jazzing this up a bit when I do my node app jazz work. I just wanted to fix this for anyone testing commands right now. 